### PR TITLE
feat: metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1849,6 +1849,7 @@ dependencies = [
  "hickory-resolver",
  "hickory-server",
  "http 1.1.0",
+ "iroh-metrics 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iroh-net",
  "parking_lot",
  "pkarr",
@@ -1858,6 +1859,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile 1.0.4",
  "serde",
+ "struct_iterable",
  "strum 0.26.2",
  "tokio",
  "tokio-rustls",
@@ -1884,6 +1886,27 @@ dependencies = [
  "pin-project",
  "smallvec",
  "tokio",
+]
+
+[[package]]
+name = "iroh-metrics"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4b29ecbd3a1581e5b73c59cdff20225690f5eed32f293728563a0d06c2c91fe"
+dependencies = [
+ "anyhow",
+ "erased_set",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
+ "once_cell",
+ "prometheus-client",
+ "reqwest",
+ "serde",
+ "struct_iterable",
+ "time",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1934,7 +1957,7 @@ dependencies = [
  "hyper-util",
  "igd",
  "iroh-base",
- "iroh-metrics",
+ "iroh-metrics 0.13.0 (git+https://github.com/n0-computer/iroh.git?branch=feat/dns)",
  "libc",
  "netlink-packet-core",
  "netlink-packet-route",

--- a/iroh-dns-server/Cargo.toml
+++ b/iroh-dns-server/Cargo.toml
@@ -46,6 +46,8 @@ redb = "2.0.0"
 tower-http = { version = "0.5.2", features = ["cors", "trace"] }
 tower_governor = "0.3.2"
 governor = "0.6.3"
+iroh-metrics = "0.13.0"
+struct_iterable = "0.1.1"
 
 [dev-dependencies]
 hickory-resolver = "0.24.0"

--- a/iroh-dns-server/src/lib.rs
+++ b/iroh-dns-server/src/lib.rs
@@ -6,5 +6,6 @@ pub mod state;
 #[cfg(feature = "mainline-dht")]
 pub mod mainline;
 
+pub mod metrics;
 pub mod store;
 pub mod util;

--- a/iroh-dns-server/src/metrics.rs
+++ b/iroh-dns-server/src/metrics.rs
@@ -1,0 +1,59 @@
+use iroh_metrics::core::{Core, Counter, Metric};
+use struct_iterable::Iterable;
+
+#[derive(Debug, Clone, Iterable)]
+pub struct Metrics {
+    pub pkarr_publish_update: Counter,
+    pub pkarr_publish_noop: Counter,
+    pub pkarr_publish_error: Counter,
+    pub dns_requests: Counter,
+    pub dns_requests_udp: Counter,
+    pub dns_requests_https: Counter,
+    pub dns_lookup_success: Counter,
+    pub dns_lookup_notfound: Counter,
+    pub dns_lookup_error: Counter,
+    pub http_requests: Counter,
+    pub http_requests_success: Counter,
+    pub http_requests_error: Counter,
+    pub http_requests_duration_ms: Counter,
+    pub store_packets_inserted: Counter,
+    pub store_packets_removed: Counter,
+    pub store_packets_updated: Counter,
+}
+
+impl Default for Metrics {
+    fn default() -> Self {
+        Self {
+            pkarr_publish_update: Counter::new("Number of pkarr relay puts that updated the state"),
+            pkarr_publish_noop: Counter::new(
+                "Number of pkarr relay puts that did not update the state",
+            ),
+            pkarr_publish_error: Counter::new("Number of pkarr relay puts that failed"),
+            dns_requests: Counter::new("DNS requests (total)"),
+            dns_requests_udp: Counter::new("DNS requests via UDP"),
+            dns_requests_https: Counter::new("DNS requests via HTTPS (DoH)"),
+            dns_lookup_success: Counter::new("DNS lookup responses with at least one answer"),
+            dns_lookup_notfound: Counter::new("DNS lookup responses with no answers"),
+            dns_lookup_error: Counter::new("DNS lookup responses which failed"),
+            http_requests: Counter::new("Number of HTTP requests"),
+            http_requests_success: Counter::new("Number of HTTP requests with a 2xx status code"),
+            http_requests_error: Counter::new("Number of HTTP requests with a non-2xx status code"),
+            http_requests_duration_ms: Counter::new("Total duration of all HTTP requests"),
+            store_packets_inserted: Counter::new("Signed packets inserted into the store"),
+            store_packets_removed: Counter::new("Signed packets removed from the store"),
+            store_packets_updated: Counter::new("Number of updates to existing packets"),
+        }
+    }
+}
+
+impl Metric for Metrics {
+    fn name() -> &'static str {
+        "dns_server"
+    }
+}
+
+pub fn init_metrics() {
+    Core::init(|reg, metrics| {
+        metrics.insert(Metrics::new(reg));
+    });
+}


### PR DESCRIPTION
This adds metrics collection and a metrics server. 

Uses `iroh-metrics` under the hood.

Exposes the following metrics:

```sh
$ curl -s localhost:9090
# HELP dns_server_pkarr_publish_update Number of pkarr relay puts that updated the state.
# TYPE dns_server_pkarr_publish_update counter
dns_server_pkarr_publish_update_total 6
# HELP dns_server_pkarr_publish_noop Number of pkarr relay puts that did not update the state.
# TYPE dns_server_pkarr_publish_noop counter
dns_server_pkarr_publish_noop_total 0
# HELP dns_server_pkarr_publish_error Number of pkarr relay puts that failed.
# TYPE dns_server_pkarr_publish_error counter
dns_server_pkarr_publish_error_total 0
# HELP dns_server_dns_requests DNS requests (total).
# TYPE dns_server_dns_requests counter
dns_server_dns_requests_total 6
# HELP dns_server_dns_requests_udp DNS requests via UDP.
# TYPE dns_server_dns_requests_udp counter
dns_server_dns_requests_udp_total 6
# HELP dns_server_dns_requests_https DNS requests via HTTPS (DoH).
# TYPE dns_server_dns_requests_https counter
dns_server_dns_requests_https_total 0
# HELP dns_server_dns_lookup_success DNS lookup responses with at least one answer.
# TYPE dns_server_dns_lookup_success counter
dns_server_dns_lookup_success_total 5
# HELP dns_server_dns_lookup_notfound DNS lookup responses with no answers.
# TYPE dns_server_dns_lookup_notfound counter
dns_server_dns_lookup_notfound_total 1
# HELP dns_server_dns_lookup_error DNS lookup responses which failed.
# TYPE dns_server_dns_lookup_error counter
dns_server_dns_lookup_error_total 0
# HELP dns_server_http_requests Number of HTTP requests.
# TYPE dns_server_http_requests counter
dns_server_http_requests_total 12
# HELP dns_server_http_requests_success Number of HTTP requests with a 2xx status code.
# TYPE dns_server_http_requests_success counter
dns_server_http_requests_success_total 12
# HELP dns_server_http_requests_error Number of HTTP requests with a non-2xx status code.
# TYPE dns_server_http_requests_error counter
dns_server_http_requests_error_total 0
# HELP dns_server_http_requests_duration_ms Total duration of all HTTP requests.
# TYPE dns_server_http_requests_duration_ms counter
dns_server_http_requests_duration_ms_total 147
# HELP dns_server_store_packets_inserted Signed packets inserted into the store.
# TYPE dns_server_store_packets_inserted counter
dns_server_store_packets_inserted_total 2
# HELP dns_server_store_packets_removed Signed packets removed from the store.
# TYPE dns_server_store_packets_removed counter
dns_server_store_packets_removed_total 0
# HELP dns_server_store_packets_updated Number of updates to existing packets.
# TYPE dns_server_store_packets_updated counter
dns_server_store_packets_updated_total 4
# EOF
```