### PR TITLE
fix: change default dns port

### DIFF
--- a/iroh-dns-server/config.dev.toml
+++ b/iroh-dns-server/config.dev.toml
@@ -8,7 +8,7 @@ cert_mode = "self_signed"
 letsencrypt_prod = false
 
 [dns]
-port = 5353
+port = 5300
 default_soa = "dns1.irohdns.example hostmaster.irohdns.example 0 10800 3600 604800 3600"
 default_ttl = 900
 origin = "irohdns.example."

--- a/iroh-dns-server/examples/publish.rs
+++ b/iroh-dns-server/examples/publish.rs
@@ -77,7 +77,7 @@ async fn main() -> Result<()> {
     match args.env {
         Env::IrohTest => println!("dig {} TXT", node_domain(&node_id, N0_TESTDNS_NODE_ORIGIN)),
         Env::LocalDev => println!(
-            "dig @localhost -p 5353 {} TXT",
+            "dig @localhost -p 5300 {} TXT",
             node_domain(&node_id, EXAMPLE_ORIGIN)
         ),
     }

--- a/iroh-dns-server/examples/resolve.rs
+++ b/iroh-dns-server/examples/resolve.rs
@@ -11,7 +11,7 @@ use iroh_net::dns::node_info::lookup_by_domain;
 use iroh_net::dns::node_info::lookup_by_id;
 use iroh_net::NodeId;
 
-const LOCALHOST_DNS: &str = "127.0.0.1:5353";
+const LOCALHOST_DNS: &str = "127.0.0.1:5300";
 const EXAMPLE_ORIGIN: &str = "irohdns.example";
 
 #[derive(ValueEnum, Clone, Debug, Default)]
@@ -19,7 +19,7 @@ pub enum Env {
     /// Use cloudflare and the irohdns test server at testdns.iroh.link
     #[default]
     IrohTest,
-    /// Use a localhost domain server listening on port 5353
+    /// Use a localhost domain server listening on port 5300
     LocalDev,
 }
 

--- a/iroh-dns-server/src/config.rs
+++ b/iroh-dns-server/src/config.rs
@@ -78,7 +78,7 @@ impl Default for Config {
                     "dns1.irohdns.example hostmaster.irohdns.example 0 10800 3600 604800 3600"
                         .to_string(),
                 origin: "irohdns.example.".to_string(),
-                port: 5353,
+                port: 5300,
                 default_ttl: 900,
                 additional_origins: vec!["iroh.".to_string(), ".".to_string()],
                 ipv4_addr: Some(Ipv4Addr::LOCALHOST),

--- a/iroh-dns-server/src/dns.rs
+++ b/iroh-dns-server/src/dns.rs
@@ -82,6 +82,7 @@ pub async fn serve(
         TcpListener::bind(sock_addr).await?,
         TCP_TIMEOUT, // Duration::from_millis(settings.timeout_ms),
     );
+    tracing::info!("DNS server listening on {}", sock_addr);
 
     tokio::select! {
         _ = server.block_until_done() => {


### PR DESCRIPTION
5353 is occupied by a multicast-dns server for bonjour on mac, so it is not a good default port.

Also, log the actual listen port on info level when starting the dns task.